### PR TITLE
switch back to first workspace on monitor after mapping

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -80,7 +80,7 @@ void mapWorkspacesToMonitors()
                 g_pCompositor->moveWorkspaceToMonitor(workspace, monitor.get());
             }
         }
-
+        HyprlandAPI::invokeHyprctlCommand("dispatch", "workspace " + std::to_string(workspaceIndex));
         workspaceIndex += workspaceCount;
     }
 }


### PR DESCRIPTION
Makes it so the first workspace is selected on every monitor after the mapping is done. 