### PR TITLE
Changed the workspace separation

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,9 @@ It also provides the following config values
 
 Keep in mind that if you're using, for example, the `wlr/workspaces` widgets in [waybar](https://github.com/Alexays/Waybar), this will require a change to your config. You should set `all-outputs` to `false`, and adjust the icon mapping.
 
-If your workspace-per-monitor count is 10, the first monitor will have workspaces 1-10, the second 11-20 and so on. They will be accessed via numbers 1-10 while your mouse is on a given monitor.
+# Workings
+When you are on monitor `(ID=N)` and want to move to workspace `W`,
+the actual workspace you go to is given by `(W - 1) * monitors + N + 1`.
 
 # Special thanks
 - [hyprsome](https://github.com/sopa0/hyprsome): An earlier project of similar nature

--- a/hyprload.toml
+++ b/hyprload.toml
@@ -1,6 +1,6 @@
 [split-monitor-workspaces]
 description = "Split monitor workspaces"
-version = "1.0.0"
+version = "1.1.0"
 author = "Duckonaut"
 
 [split-monitor-workspaces.build]


### PR DESCRIPTION
Hello. So I installed the plugin and it did not just work. Going to a workspace would just go to another monitor and create a mess. I think this is because i have monitors with IDs (from left to right) 0, 2, 1 rather than 0, 1, 2. (I don't know why that is, but this plugin should work nonetheless).

Furthermore, the plugin uses `g_vMonitorWorkspaceMap` to keep track of workspaces, which could totally be avoided.

My solution is to compute the workspace as such: if you are on monitor ID=N and want to go to workspace W, the actual workspace is given by `(W - 1) * monitors + N + 1`. This means that `1`, `2` and `3` are the first workspace of each monitor, `4`, `5`and `6` are the second workspace of each monitor and so on.
At initialization, or when a monitor is added/removed, the formula for the workspace is reversed and every workspace is moved to its correct monitor.

This solution is more simple and the workspace computation can be implemented elsewhere.
@zjeffer I think some of your problems may be solved by using this approach.

Please test the code as I only tested it with my weird monitor IDs, but it should work regardless of the ID order.
I also think it will be easier to implement features such as `previous` and `m+1` (those things) since everything is just a simple computation. Tell me what you think :)