### PR TITLE
nix: clean up flake and ignore nix build artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ build/
 .cache/
 *.so
 compile_flags.txt
+result/ 

--- a/flake.lock
+++ b/flake.lock
@@ -47,6 +47,21 @@
         "type": "github"
       }
     },
+    "nix-filter": {
+      "locked": {
+        "lastModified": 1687178632,
+        "narHash": "sha256-HS7YR5erss0JCaUijPeyg2XrisEb959FIct3n2TMGbE=",
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "rev": "d90c75e8319d0dd9be67d933d8eb9d0894ec9174",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "nix-filter",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1691654369,
@@ -65,7 +80,8 @@
     },
     "root": {
       "inputs": {
-        "hyprland": "hyprland"
+        "hyprland": "hyprland",
+        "nix-filter": "nix-filter"
       }
     },
     "systems": {

--- a/result
+++ b/result
@@ -1,1 +1,0 @@
-/nix/store/bjf217i1id0y2wqsmgrfl7wjbb9f913g-split-monitor-workspaces-0.1


### PR DESCRIPTION
## Changes made
- `result/` is only a symlink to the store, which serves zero purpose on a git repeository - added to `.gitignore`
- renamed `hyprlandSystems` function to a little more descriptive `forHyprlandSystems`
- added `nix-filter` to scrub source directory before build
- added `BUILT_WITH_NOXWAYLAND = false` to the derivation in order to make it overridable with `.overrideAttrs`
- formatting via alejandra because nixpkgs-fmt sucks 👍🏻 

