### PR TITLE
Improvements & fixes 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ build/
 .cache/
 *.so
 compile_flags.txt
+compile_commands.json
 result/ 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -32,7 +32,7 @@ const std::string& getWorkspaceFromMonitor(CMonitor* monitor, const std::string&
         workspaceIndex = std::stoi(workspace) - 1;
     }
     catch (std::invalid_argument&) {
-        Debug::log(WARN, "Invalid workspace index: %s", workspace.c_str());
+        Debug::log(WARN, "Invalid workspace index: {}", workspace);
         return workspace;
     }
 
@@ -85,7 +85,7 @@ void changeMonitor(bool quiet, std::string value)
         delta = -1;
     }
     else {
-        Debug::log(WARN, "Invalid monitor value: %s", value.c_str());
+        Debug::log(WARN, "Invalid monitor value: {}", value);
         return;
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -17,7 +17,7 @@
 
 const std::string k_workspaceCount = "plugin:split-monitor-workspaces:count";
 const std::string k_keepFocused = "plugin:split-monitor-workspaces:keep_focused";
-const CColor s_pluginColor = {0x61 / 255.0f, 0xAF / 255.0f, 0xEF / 255.0f, 1.0f};
+const CColor s_pluginColor = {0x61 / 255.0F, 0xAF / 255.0F, 0xEF / 255.0F, 1.0F};
 
 std::map<uint64_t, std::vector<std::string>> g_vMonitorWorkspaceMap;
 
@@ -47,28 +47,28 @@ const std::string& getWorkspaceFromMonitor(CMonitor* monitor, const std::string&
     return g_vMonitorWorkspaceMap[monitor->ID][workspaceIndex];
 }
 
-void splitWorkspace(std::string workspace)
+void splitWorkspace(const std::string& workspace)
 {
     CMonitor* monitor = g_pCompositor->getMonitorFromCursor();
 
     HyprlandAPI::invokeHyprctlCommand("dispatch", "workspace " + getWorkspaceFromMonitor(monitor, workspace));
 }
 
-void splitMoveToWorkspace(std::string workspace)
+void splitMoveToWorkspace(const std::string& workspace)
 {
     CMonitor* monitor = g_pCompositor->getMonitorFromCursor();
 
     HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspace " + getWorkspaceFromMonitor(monitor, workspace));
 }
 
-void splitMoveToWorkspaceSilent(std::string workspace)
+void splitMoveToWorkspaceSilent(const std::string& workspace)
 {
     CMonitor* monitor = g_pCompositor->getMonitorFromCursor();
 
     HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspacesilent " + getWorkspaceFromMonitor(monitor, workspace));
 }
 
-void changeMonitor(bool quiet, std::string value)
+void changeMonitor(bool quiet, const std::string& value)
 {
     CMonitor* monitor = g_pCompositor->getMonitorFromCursor();
 
@@ -107,12 +107,12 @@ void changeMonitor(bool quiet, std::string value)
     }
 }
 
-void splitChangeMonitorSilent(std::string value)
+void splitChangeMonitorSilent(const std::string& value)
 {
     changeMonitor(true, value);
 }
 
-void splitChangeMonitor(std::string value)
+void splitChangeMonitor(const std::string& value)
 {
     changeMonitor(false, value);
 }
@@ -149,7 +149,7 @@ void mapWorkspacesToMonitors()
     }
 }
 
-void refreshMapping(void*, SCallbackInfo&, std::any)
+void refreshMapping(void* /*unused*/, SCallbackInfo& /*unused*/, std::any /*unused*/)
 {
     mapWorkspacesToMonitors();
 }


### PR DESCRIPTION
* Fixes the Debug::log method using the old format (`%s => {}`)
* Added compile_commands.json to gitignore. This file is generated by `clangd`.
* Added an install_and_reload target in the Makefile, which builds the plugin, unloads the old one, installs the new one and loads it. Very useful for development
* Applied some clang-tidy suggestions to improve code quality (mainly making some arguments `const &`)