### PR TITLE
Add support for Hyprland persistent workspace rules, fix config values not getting used, general improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ build/
 *.so
 compile_flags.txt
 result/ 
+.vscode/
+compile_commands.json

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,7 @@
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/helpers/Color.hpp>
-#include <hyprland/src/helpers/Workspace.hpp>
+#include <hyprland/src/desktop/Workspace.hpp>
 #include <hyprland/src/managers/KeybindManager.hpp>
 
 #include "globals.hpp"

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -96,13 +96,13 @@ void changeMonitor(bool quiet, std::string value)
 
     nextMonitor = g_pCompositor->m_vMonitors[nextMonitorIndex].get();
 
-    int nextWorkspace = nextMonitor->activeWorkspace;
+    int nextWorkspaceID = nextMonitor->activeWorkspace->m_iID;
 
     if (quiet) {
-        HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspacesilent " + std::to_string(nextWorkspace));
+        HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspacesilent " + std::to_string(nextWorkspaceID));
     }
     else {
-        HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspace " + std::to_string(nextWorkspace));
+        HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspace " + std::to_string(nextWorkspaceID));
     }
 }
 
@@ -142,7 +142,7 @@ void fixWorkspaceArrangement()
     // for all monitors in the map, move the workspaces to the correct monitor
     for (auto& monitor : g_vMonitorWorkspaceMap) {
         for (auto& workspace : monitor.second) {
-            CWorkspace* workspacePtr = g_pCompositor->getWorkspaceByName(workspace);
+            PHLWORKSPACE workspacePtr = g_pCompositor->getWorkspaceByName(workspace);
             if (workspacePtr != nullptr) {
                 auto* const monitorPtr = g_pCompositor->getMonitorFromID(monitor.first);
                 if (monitorPtr == nullptr) {
@@ -196,7 +196,7 @@ void mapWorkspacesToMonitors()
             std::string workspaceName = std::to_string(i);
             g_vMonitorWorkspaceMap[monitor->ID].push_back(workspaceName);
             HyprlandAPI::invokeHyprctlCommand("keyword", "workspace " + workspaceName + "," + monitor->szName);
-            CWorkspace* workspace = g_pCompositor->getWorkspaceByName(workspaceName);
+            PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByName(workspaceName);
 
             if (workspace != nullptr) {
                 g_pCompositor->moveWorkspaceToMonitor(workspace, monitor.get());

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -192,8 +192,8 @@ void mapWorkspacesToMonitors()
             HyprlandAPI::invokeHyprctlCommand("dispatch", "workspace " + std::to_string(workspaceIndex));
         }
     }
-    fixWorkspaceArrangement();
     writeWorkspaceRules(workspaceRules);
+    HyprlandAPI::reloadConfig();
 }
 
 void refreshMapping(void*, SCallbackInfo&, std::any)


### PR DESCRIPTION
* Add support for Hyprland persistent workspace rules
* Fix config values not getting used (fixes #13)
* Fix workspaces not being moved to correct monitor
* Added `.vscode` and `compile_commands.json` (generated by clangd) to `.gitignore`
* More logging
* General improvements
* Fix build since Hyprland v38 changes (PHLWORKSPACE error) (#58)

The persistent workspace rules are written to /tmp/hyprland-workspace-rules. This file can be loaded in your Hyprland config like this: https://github.com/zjeffer/dotfiles/blob/afd7c436d514f151c79b84cf732ab70c538c79fe/.config/hypr/configs/workspace_rules.conf#L1-L2
This can be used in combination with Waybar (since [this PR](https://github.com/Alexays/Waybar/pull/2603)), to dynamically make all your workspaces persistent.
