### PR TITLE
Remove old dependency "Workspace.hpp"

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,6 @@
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/helpers/Color.hpp>
-#include <hyprland/src/helpers/Workspace.hpp>
 #include <hyprland/src/managers/KeybindManager.hpp>
 
 #include "globals.hpp"


### PR DESCRIPTION
Upstream removed src/helpers/Workspace.hpp so I removed it here too, plugin still works fine without it if build against the git version