### PR TITLE
Added basic .clang-tidy file, fix clang-tidy suggestions

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -3,7 +3,6 @@ BreakBeforeBraces: Stroustrup
 TabWidth: 4
 IndentWidth: 4
 UseTab: Never
-AllowShortIfStatementsOnASingleLine: false
 IndentCaseLabels: true
 ColumnLimit: 200
 PointerAlignment: Left

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,0 +1,18 @@
+Checks: >
+  -*,
+  bugprone-*
+  misc-*,
+  modernize-*,
+  performance-*,
+  portability-*,
+  readability-*,
+  -fuchsia-trailing-return,
+  -readability-magic-numbers,
+  -modernize-use-nodiscard,
+  -modernize-use-trailing-return-type,
+  -readability-braces-around-statements,
+  -readability-redundant-access-specifiers,
+  -readability-redundant-member-init,
+  -readability-redundant-string-init,
+  -readability-identifier-length
+

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2,8 +2,8 @@
 #include <cstdint>
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
-#include <hyprland/src/helpers/Color.hpp>
 #include <hyprland/src/desktop/Workspace.hpp>
+#include <hyprland/src/helpers/Color.hpp>
 #include <hyprland/src/managers/KeybindManager.hpp>
 
 #include "globals.hpp"
@@ -150,7 +150,8 @@ void fixWorkspaceArrangement()
                     continue;
                 }
                 g_pCompositor->moveWorkspaceToMonitor(workspacePtr, monitorPtr);
-            } else {
+            }
+            else {
                 Debug::log(WARN, "[split-monitor-workspaces] fixWorkspaceArrangement: Workspace not found: {}", workspace);
             }
         }
@@ -166,13 +167,11 @@ void mapWorkspacesToMonitors()
     static const auto* const workspaceCountPtr = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, k_workspaceCount)->getDataStaticPtr();
     static const auto* const keepFocusedPtr = (Hyprlang::INT* const*)HyprlandAPI::getConfigValue(PHANDLE, k_keepFocused)->getDataStaticPtr();
 
-    if (workspaceCountPtr == nullptr)
-    {
+    if (workspaceCountPtr == nullptr) {
         Debug::log(WARN, "[split-monitor-workspaces] Failed to get workspace count config value");
         return;
     }
-    if (keepFocusedPtr == nullptr)
-    {
+    if (keepFocusedPtr == nullptr) {
         Debug::log(WARN, "[split-monitor-workspaces] Failed to get keep focused config value");
         return;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -15,7 +15,7 @@
 
 const std::string k_workspaceCount = "plugin:split-monitor-workspaces:count";
 const std::string k_keepFocused = "plugin:split-monitor-workspaces:keep_focused";
-const CColor s_pluginColor = {0x61 / 255.0f, 0xAF / 255.0f, 0xEF / 255.0f, 1.0f};
+const CColor s_pluginColor = {0x61 / 255.0F, 0xAF / 255.0F, 0xEF / 255.0F, 1.0F};
 
 std::map<uint64_t, std::vector<std::string>> g_vMonitorWorkspaceMap;
 
@@ -46,28 +46,28 @@ const std::string& getWorkspaceFromMonitor(CMonitor* monitor, const std::string&
     return g_vMonitorWorkspaceMap[monitor->ID][workspaceIndex];
 }
 
-void splitWorkspace(std::string workspace)
+void splitWorkspace(const std::string& workspace)
 {
     CMonitor* monitor = g_pCompositor->getMonitorFromCursor();
 
     HyprlandAPI::invokeHyprctlCommand("dispatch", "workspace " + getWorkspaceFromMonitor(monitor, workspace));
 }
 
-void splitMoveToWorkspace(std::string workspace)
+void splitMoveToWorkspace(const std::string& workspace)
 {
     CMonitor* monitor = g_pCompositor->getMonitorFromCursor();
 
     HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspace " + getWorkspaceFromMonitor(monitor, workspace));
 }
 
-void splitMoveToWorkspaceSilent(std::string workspace)
+void splitMoveToWorkspaceSilent(const std::string& workspace)
 {
     CMonitor* monitor = g_pCompositor->getMonitorFromCursor();
 
     HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspacesilent " + getWorkspaceFromMonitor(monitor, workspace));
 }
 
-void changeMonitor(bool quiet, std::string value)
+void changeMonitor(bool quiet, const std::string& value)
 {
     CMonitor* monitor = g_pCompositor->getMonitorFromCursor();
 
@@ -106,12 +106,12 @@ void changeMonitor(bool quiet, std::string value)
     }
 }
 
-void splitChangeMonitorSilent(std::string value)
+void splitChangeMonitorSilent(const std::string& value)
 {
     changeMonitor(true, value);
 }
 
-void splitChangeMonitor(std::string value)
+void splitChangeMonitor(const std::string& value)
 {
     changeMonitor(false, value);
 }
@@ -214,12 +214,12 @@ void mapWorkspacesToMonitors()
     HyprlandAPI::reloadConfig();
 }
 
-void refreshMapping(void*, SCallbackInfo&, std::any)
+void refreshMapping(void* /*unused*/, SCallbackInfo& /*unused*/, std::any /*unused*/)
 {
     mapWorkspacesToMonitors();
 }
 
-void configReloadedCallback(void*, SCallbackInfo&, std::any)
+void configReloadedCallback(void* /*unused*/, SCallbackInfo& /*unused*/, std::any /*unused*/)
 {
     // anything you call in this function should not reload the config, as it will cause an infinite loop
     Debug::log(INFO, "[split-monitor-workspaces] Config reloaded");


### PR DESCRIPTION
To ensure code quality is kept high, I added a clang-tidy file that contributors can use to get hints to improve their code. It has some basic checks that I think are reasonable but not annoying.
I applied some of the suggestions clang-tidy gave me with this file, mostly stuff about making function parameters `const &` instead of copying needlessly.

I also fixed the clang-format file (a key was duplicated which caused the formatter to stop working), and then formatted main.cpp again after the fix.