### PR TITLE
Fix build after Hyprland's PluginAPI.cpp changes

### DIFF
--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -2,7 +2,8 @@
 name = "split-monitor-workspaces"
 authors = ["Duckonaut", "zjeffer"]
 commit_pins = [
-    ["360ede79d124ffdeebbe8401f1ac4bc0dbec2c91", "f7a306396da163422048fd38eecd92c68ce21e58"]  # 0.38.1
+    ["360ede79d124ffdeebbe8401f1ac4bc0dbec2c91", "f7a306396da163422048fd38eecd92c68ce21e58"], # 0.38.1
+    ["fe7b748eb668136dd0558b7c8279bfcd7ab4d759", "b0ee3953eaeba70f3fba7c4368987d727779826a"]  # 0.39.1
 ]
 
 [split-monitor-workspaces]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,9 +19,9 @@ const CColor s_pluginColor = {0x61 / 255.0f, 0xAF / 255.0f, 0xEF / 255.0f, 1.0f}
 
 std::map<uint64_t, std::vector<std::string>> g_vMonitorWorkspaceMap;
 
-static HOOK_CALLBACK_FN* e_monitorAddedHandle = nullptr;
-static HOOK_CALLBACK_FN* e_monitorRemovedHandle = nullptr;
-static HOOK_CALLBACK_FN* e_configReloadedHandle = nullptr;
+static std::shared_ptr<HOOK_CALLBACK_FN> e_monitorAddedHandle = nullptr;
+static std::shared_ptr<HOOK_CALLBACK_FN> e_monitorRemovedHandle = nullptr;
+static std::shared_ptr<HOOK_CALLBACK_FN> e_configReloadedHandle = nullptr;
 
 const std::string& getWorkspaceFromMonitor(CMonitor* monitor, const std::string& workspace)
 {


### PR DESCRIPTION
The return type of `HyprlandAPI::registerCallbackDynamic` was changed to use shared_ptrs:

https://github.com/hyprwm/Hyprland/commit/4ad739ec63c9a11f0537a884ae2a4c56d6bab10b#diff-050d11d25a694faf8b331caa5af4445e6c1a5d29e8b49f54de46fd784bba95a4R141

I also added a pin for 0.39.1, so this plugin will still work for people using the release.