### PR TITLE
Changemonitor wrapping behavior (fixed with mirrored/removed monitors)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,10 +109,19 @@ void changeMonitor(bool quiet, const std::string& value)
         return;
     }
 
-    // The index is used instead of the monitorID because using the monitorID won't work if monitors are removed or are mirrored
+    // The index is used instead of the monitorID because using the monitorID won't work if monitors are removed or mirrored
     // as there would be gaps in the monitorID sequence
-    auto const f = [&](const auto& mon) { return mon.get() == monitor; };
-    int currentMonitorIndex = std::distance(g_pCompositor->m_vMonitors.begin(), std::find_if(g_pCompositor->m_vMonitors.begin(), g_pCompositor->m_vMonitors.end(), f));
+    int currentMonitorIndex = -1;
+    for (size_t i = 0; i < g_pCompositor->m_vMonitors.size(); i++) {
+        if (g_pCompositor->m_vMonitors[i].get() == monitor) {
+            currentMonitorIndex = i;
+            break;
+        }
+    }
+    if (currentMonitorIndex == -1) {
+        Debug::log(WARN, "[split-monitor-workspaces] Monitor ID {} not found in monitor list?", monitor->ID);
+        return;
+    }
 
     int nextMonitorIndex = (monitorCount + currentMonitorIndex + delta) % monitorCount;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,11 +109,7 @@ void changeMonitor(bool quiet, const std::string& value)
         return;
     }
 
-    int nextMonitorIndex = (monitor->ID + delta) % monitorCount;
-
-    if (nextMonitorIndex < 0) {
-        nextMonitorIndex += monitorCount;
-    }
+    int nextMonitorIndex = (monitorCount + monitor->ID + delta) % monitorCount;
 
     nextMonitor = g_pCompositor->m_vMonitors[nextMonitorIndex].get();
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,7 +109,12 @@ void changeMonitor(bool quiet, const std::string& value)
         return;
     }
 
-    int nextMonitorIndex = (monitorCount + monitor->ID + delta) % monitorCount;
+    // The index is used instead of the monitorID because using the monitorID won't work if monitors are removed or are mirrored
+    // as there would be gaps in the monitorID sequence
+    auto const f = [&](const auto& mon) { return mon.get() == monitor; };
+    int currentMonitorIndex = std::distance(g_pCompositor->m_vMonitors.begin(), std::find_if(g_pCompositor->m_vMonitors.begin(), g_pCompositor->m_vMonitors.end(), f));
+
+    int nextMonitorIndex = (monitorCount + currentMonitorIndex + delta) % monitorCount;
 
     nextMonitor = g_pCompositor->m_vMonitors[nextMonitorIndex].get();
 


### PR DESCRIPTION
Improves upon #45 (I couldn't push to that PR so I'm creating a new one). 

I have a mirrored display which gets ID 1, while my other monitors have ID 0, 2, 3. #45 didn't work for me because it tried to move my workspace to a monitor that had an ID, but didn't actually 'exist' (because it's mirrored to the monitor with ID 3).
I think the same bug would happen if you remove a monitor. 

CC @UwUnyaa

closes #41