### PR TITLE
add pin for Hyprland 0.40.0

### DIFF
--- a/hyprpm.toml
+++ b/hyprpm.toml
@@ -3,7 +3,8 @@ name = "split-monitor-workspaces"
 authors = ["Duckonaut", "zjeffer"]
 commit_pins = [
     ["360ede79d124ffdeebbe8401f1ac4bc0dbec2c91", "f7a306396da163422048fd38eecd92c68ce21e58"], # 0.38.1
-    ["fe7b748eb668136dd0558b7c8279bfcd7ab4d759", "b0ee3953eaeba70f3fba7c4368987d727779826a"]  # 0.39.1
+    ["fe7b748eb668136dd0558b7c8279bfcd7ab4d759", "b0ee3953eaeba70f3fba7c4368987d727779826a"], # 0.39.1
+    ["cba1ade848feac44b2eda677503900639581c3f4", "b40147d96d62a9e9bbc56b18ea421211ee598357"]  # 0.40.0
 ]
 
 [split-monitor-workspaces]


### PR DESCRIPTION
Now that there's a breaking change in both Hyprland since 0.40.0, and this plugin has been updated to reflect that breaking change (05b878f11ba40e4cf4748004a9bf4d08c52f7a01), we should pin the Hyprland release to the commit before that (b40147d96d62a9e9bbc56b18ea421211ee598357), so that people who use Hyprland 0.40.0 won't install the latest git version of the plugin.