### PR TITLE
Skip mirrored monitors

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -236,6 +236,12 @@ void mapWorkspacesToMonitors()
     std::vector<std::string> workspaceRules;
     writeWorkspaceRules(workspaceRules); // clear the file first
     for (auto& monitor : g_pCompositor->m_vMonitors) {
+        if (monitor->isMirror())
+        {
+            Debug::log(INFO, "[split-monitor-workspaces] Skipping mirrored monitor {}", monitor->szName);
+            continue;
+        }
+
         int workspaceIndex = monitor->ID * workspaceCount + 1;
 
         std::string logMessage =


### PR DESCRIPTION
Mirrored monitors don't create workspaces anyway, as they are mirrored to another monitor that does have them.

This fixes an issue I was having where my workspacerules included persistent workspaces for my mirrored monitor, causing my Waybar to sometimes not destroy those workspaces properly.