### PR TITLE
Build pinned commit corresponding to latest Hyprland release

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Build on latest Hyprland git commit
 
 on:
   pull_request:
@@ -19,9 +19,8 @@ jobs:
       image: duckonaut/hyprland-arch:latest
     steps:
     - name: Install dependencies
-      # TODO: remove hyprwayland-scanner-git once hyprland-git properly depends on it
       run: |
-        sudo -u user sh -c "paru -Syu --noconfirm hyprwayland-scanner-git hyprland-git"
+        sudo -u user sh -c "paru -Syu --noconfirm hyprland-git"
 
     - name: Checkout current repository
       uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,57 @@
+name: Build on latest Hyprland release
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+  schedule:
+    # run every night at 2AM (the base docker image is updated at midnight)
+    - cron: '0 2 * * *' 
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container:
+      # image built from the Dockerfile in the .github/ folder
+      image: duckonaut/hyprland-arch:latest
+    steps:
+    - name: Install dependencies
+      run: |
+        pacman -Syu --noconfirm hyprland meson ninja
+
+    - name: Get version from installed Hyprland
+      run: |
+        hash=$(awk -F'"' '/GIT_COMMIT_HASH/ { print $2 }' /usr/include/hyprland/src/version.h)
+        if [ -z "$hash" ]; then
+          echo "Failed to get GIT_COMMIT_HASH from /usr/include/hyprland/src/version.h"
+          exit 1
+        fi
+        echo "GIT_COMMIT_HASH=$hash" >> $GITHUB_ENV
+
+    - name: Checkout current repository and checkout pinned commit
+      uses: actions/checkout@v4
+      with:
+        fetch-depth: 0 # to allow checkout out a specific commit later
+
+    - name: Get pinned commit from hyprpm.toml file
+      run: |
+        commit=$(grep -F "$GIT_COMMIT_HASH" hyprpm.toml | awk -F'"' '{print $4}')
+        if [ -z "$commit" ]; then
+          echo "Failed to get pinned commit from hyprpm.toml with GIT_COMMIT_HASH=$GIT_COMMIT_HASH"
+          exit 1
+        fi
+        echo "PINNED_COMMIT=$commit" >> $GITHUB_ENV
+
+    - name: Checkout pinned commit
+      run: |
+        echo "Checking out pinned commit $PINNED_COMMIT"
+        git config --global --add safe.directory /__w/split-monitor-workspaces/split-monitor-workspaces # fix dubious ownership warning
+        git checkout $PINNED_COMMIT
+
+    - name: Build current repository
+      run: |
+        meson setup build --wipe
+        ninja -C build


### PR DESCRIPTION
This PR adds a new GitHub action to build the pinned commit that corresponds to the latest Hyprland release installed by Arch's `hyprland` package. 

This will be useful when a new Hyprland release is created, then we'll know to update the pinned commits because the build will (most likely) fail.