### PR TITLE
readme: bump minimum Hyprland version to 0.38.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 A small plugin to provide `awesome`/`dwm`-like behavior with workspaces: split them between monitors and provide independent numbering
 
 # Requirements
-- Hyprland >= v0.36.0
+- Hyprland >= v0.38.1
 
 # Installing
 Since Hyprland plugins don't have ABI guarantees, you *should* download the Hyprland source and compile it if you plan to use plugins.


### PR DESCRIPTION
The oldest pin we have in hyprpm.toml is 0.38.1, so that should be the minimum version.