### PR TITLE
Remove keyword workspace in mapWorkspacesToMonitors as it doesnt work anyway

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -261,7 +261,6 @@ void mapWorkspacesToMonitors()
         for (int i = workspaceIndex; i < workspaceIndex + workspaceCount; i++) {
             std::string workspaceName = std::to_string(i);
             g_vMonitorWorkspaceMap[monitor->ID].push_back(workspaceName);
-            HyprlandAPI::invokeHyprctlCommand("keyword", "workspace " + workspaceName + "," + monitor->szName);
             PHLWORKSPACE workspace = g_pCompositor->getWorkspaceByName(workspaceName);
 
             if (workspace != nullptr) {


### PR DESCRIPTION
Closes #37 

Two issues with this line:
* The correct command is `hyprctl keyword workspace <name>,monitor:<monitor_name>
* The line doesn't do anything anyway because we're reloading the config afterwards, which removes all workspacerules set by the plugin. This is why we have to use the workaround in `writeWorkspaceRules`.