### PR TITLE
Argument for split-changemonitor changed from 1 to -1 in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,8 @@ And two new ones, to move windows between monitors
 
 | Normal                    | Arguments         |
 |---------------------------|-------------------|
-| split-changemonitor       | next/prev/+1/1    |
-| split-changemonitorsilent | next/prev/+1/1    |
+| split-changemonitor       | next/prev/+1/-1    |
+| split-changemonitorsilent | next/prev/+1/-1    |
 
 It also provides the following config values
 | Name                                                    | Type      | Default   | Description                                           |


### PR DESCRIPTION
It seems that using "1" as an argument does nothing, so I believe the expected behavior is to use the argument -1 instead of 1.