### PR TITLE
Add cmake to release GitHub action dependencies

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        sudo -u user sh -c "paru -Syu --noconfirm hyprland meson ninja cpio hyprwayland-scanner hyprutils"
+        sudo -u user sh -c "paru -Syu --noconfirm hyprland meson ninja cpio hyprwayland-scanner hyprutils cmake"
 
     - name: Get version from installed Hyprland
       run: |


### PR DESCRIPTION
Apparently this is now needed: https://github.com/Duckonaut/split-monitor-workspaces/actions/runs/9532704809, while it wasn't needed before :thinking: