### PR TITLE
Proper workspace persist

### DIFF
--- a/hyprload.toml
+++ b/hyprload.toml
@@ -1,6 +1,6 @@
 [split-monitor-workspaces]
 description = "Split monitor workspaces"
-version = "1.1.0"
+version = "1.2.0"
 author = "Duckonaut"
 
 [split-monitor-workspaces.build]

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('split-monitor-workspaces', 'cpp',
-  version: '0.1',
+  version: '1.2.0',
   default_options: ['buildtype=release'],
 )
 

--- a/meson.build
+++ b/meson.build
@@ -13,6 +13,7 @@ else
 endif
 
 add_global_arguments('-DWLR_USE_UNSTABLE', language: 'cpp')
+add_global_arguments('-fno-gnu-unique', language: 'cpp')
 
 globber = run_command('find', './src', '-name', '*.cpp', check: true)
 src = globber.stdout().strip().split('\n')

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -307,14 +307,12 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle)
     HyprlandAPI::addDispatcher(PHANDLE, "split-changemonitor", splitChangeMonitor);
     HyprlandAPI::addDispatcher(PHANDLE, "split-changemonitorsilent", splitChangeMonitorSilent);
 
-    HyprlandAPI::reloadConfig();
-    g_pConfigManager->tick();
-
-    reload();
-
     e_monitorAddedHandle = HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorAdded", monitorAddedCallback);
     e_monitorRemovedHandle = HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorRemoved", monitorRemovedCallback);
     e_configReloadedHandle = HyprlandAPI::registerCallbackDynamic(PHANDLE, "configReloaded", configReloadedCallback);
+
+    // initial mapping of the workspaces will happen after plugin initialization, through the configReloadedCallback
+    // this is because Hyprland will automatically force a config reload after the plugin is loaded
 
     raiseNotification("[split-monitor-workspaces] Initialized successfully!");
     return {"split-monitor-workspaces", "Split monitor workspace namespaces", "Duckonaut", "1.2.0"};

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -19,7 +19,11 @@ auto constexpr k_enableNotifications = "plugin:split-monitor-workspaces:enable_n
 
 const CColor s_pluginColor = {0x61 / 255.0F, 0xAF / 255.0F, 0xEF / 255.0F, 1.0F};
 bool g_enableNotifications = false;
-int g_workspaceCount, g_keepFocused;
+bool g_keepFocused = false;
+int g_workspaceCount;
+
+// the first time we load the plugin, we want to switch to the first workspace on the first monitor regardless of keepFocused
+bool g_firstLoad = true;
 
 std::map<uint64_t, std::vector<std::string>> g_vMonitorWorkspaceMap;
 
@@ -203,7 +207,8 @@ void mapMonitor(CMonitor* monitor)
         workspace->m_bPersistent = true;
     }
 
-    if (g_keepFocused == 0) {
+    if (!g_keepFocused || g_firstLoad) {
+        // we also want to switch to the first workspace when the plugin is first loaded
         HyprlandAPI::invokeHyprctlCommand("dispatch", "workspace " + std::to_string(workspaceIndex));
     }
 }
@@ -254,9 +259,10 @@ void remapAllMonitors()
 void reload()
 {
     g_enableNotifications = getParamValue(k_enableNotifications) != 0;
-    g_keepFocused = getParamValue(k_keepFocused);
+    g_keepFocused = getParamValue(k_keepFocused) != 0;
     g_workspaceCount = getParamValue(k_workspaceCount);
     remapAllMonitors();
+    g_firstLoad = false;
 }
 
 void monitorAddedCallback(void* /*unused*/, SCallbackInfo& /*unused*/, std::any param)

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -256,11 +256,16 @@ void remapAllMonitors()
     }
 }
 
-void reload()
+void loadConfigValues()
 {
     g_enableNotifications = getParamValue(k_enableNotifications) != 0;
     g_keepFocused = getParamValue(k_keepFocused) != 0;
     g_workspaceCount = getParamValue(k_workspaceCount);
+}
+
+void reload()
+{
+    loadConfigValues();
     remapAllMonitors();
     g_firstLoad = false;
 }
@@ -312,6 +317,11 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle)
     HyprlandAPI::addDispatcher(PHANDLE, "split-movetoworkspacesilent", splitMoveToWorkspaceSilent);
     HyprlandAPI::addDispatcher(PHANDLE, "split-changemonitor", splitChangeMonitor);
     HyprlandAPI::addDispatcher(PHANDLE, "split-changemonitorsilent", splitChangeMonitorSilent);
+
+    // reload the config before adding the callback, so we can already use the config's values we defined above
+    HyprlandAPI::reloadConfig();
+    g_pConfigManager->tick();
+    loadConfigValues();
 
     e_monitorAddedHandle = HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorAdded", monitorAddedCallback);
     e_monitorRemovedHandle = HyprlandAPI::registerCallbackDynamic(PHANDLE, "monitorRemoved", monitorRemovedCallback);


### PR DESCRIPTION
This replaces storing a configuration file, which needs to be sourced to Hyprland configuration, with creating and setting the workplace's persistence directly.
This avoids reloading the whole Hyprland configuration, which discards any hyprctl dynamic configuration. 
Fixes #110 

I am not sure about directly accessing and modifying `workspace->m_bPersistent` on line 251, but it seems like it's the only way.