### PR TITLE
Current workspace can also count as empty

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -51,16 +51,11 @@ int getParamValue(const char* paramName)
 
 const std::string& getWorkspaceFromMonitor(CMonitor* monitor, const std::string& workspace)
 {
-    // if the workspace is "empty", we expect the new ID to be the next available ID on the given monitor (not the next ID in the global list)
+    // if the workspace is "empty", we expect the new ID to be the first available ID on the given monitor (not the first ID in the global list)
     if (workspace == "empty") {
         // get the next workspace ID that is empty on this monitor
-        PHLWORKSPACE activeWorkspace = monitor->activeWorkspace;
         for (const auto& workspaceName : g_vMonitorWorkspaceMap[monitor->ID]) {
             PHLWORKSPACE workspacePtr = g_pCompositor->getWorkspaceByName(workspaceName);
-            if (workspacePtr == activeWorkspace) {
-                // skip the currently active workspace
-                continue;
-            }
             // the workspace we want is either not yet created (=nullptr) or already created but empty (!= nullptr but no windows)
             if (workspacePtr == nullptr || g_pCompositor->getWindowsOnWorkspace(workspacePtr->m_iID) == 0) {
                 return workspaceName;


### PR DESCRIPTION
Workspace "empty" should be the **first** empty workspace, not the first or second if the first one is active.

Before this, calling `split-workspace empty` repeatedly would switch between first and second empty workspace, but this way it will always choose the first empty one, just like the Hyprland's `workspace empty` does.