### PR TITLE
Remove pacman keyring workaround again

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,9 +20,6 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        sudo pacman -Syu --noconfirm archlinux-keyring
-        sudo pacman-key --init
-        sudo pacman-key --refresh-keys
         sudo -u user sh -c "paru -Syu --noconfirm hyprland-git"
 
     - name: Checkout current repository

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,9 +20,6 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        sudo pacman -Syu --noconfirm archlinux-keyring
-        sudo pacman-key --init
-        sudo pacman-key --refresh-keys
         sudo -u user sh -c "paru -Syu --noconfirm hyprland meson ninja cpio hyprwayland-scanner hyprutils cmake"
 
     - name: Get version from installed Hyprland


### PR DESCRIPTION
This used to be necessary for some reason, but might not be anymore. It also greatly increased the time to build the CI/CD, which was annoying.

