### PR TITLE
CI/CD: Install aquamarine-git

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
     - name: Install dependencies
       run: |
-        sudo -u user sh -c "paru -Syu --noconfirm hyprland-git"
+        sudo -u user sh -c "paru -Syu --noconfirm aquamarine-git hyprland-git"
 
     - name: Checkout current repository
       uses: actions/checkout@v4


### PR DESCRIPTION
The `hyprland-git` AUR package is now dependent on `aquamarine` instead of `aquamarine-git`, but this causes paru to ask confirmation to fix the conflicts, because the `aquamarine` package installs the non-git dependencies, and we want the git ones.