### PR TITLE
Added split-cycleworkspaces dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ And two new ones, to move windows between monitors
 
 | Normal                    | Arguments         |
 |---------------------------|-------------------|
+| split-cycleworkspaces     | next/prev/+1/-1    |
 | split-changemonitor       | next/prev/+1/-1    |
 | split-changemonitorsilent | next/prev/+1/-1    |
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,15 +166,8 @@ void changeMonitor(bool quiet, const std::string& value)
 
     uint64_t monitorCount = g_pCompositor->m_vMonitors.size();
 
-    int delta = 0;
-
-    if (value == "next" || value == "+1") {
-        delta = 1;
-    }
-    else if (value == "prev" || value == "-1") {
-        delta = -1;
-    }
-    else {
+    int const delta = getDelta(value);
+    if (delta == 0) {
         Debug::log(WARN, "[split-monitor-workspaces] Invalid monitor value: {}", value.c_str());
         return;
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -48,7 +48,7 @@ int getDelta(const std::string& direction)
     if (direction == "prev" || direction == "-1") {
         return -1;
     }
-	// fallback if input is incorrect
+    // fallback if input is incorrect
     return 0;
 }
 
@@ -120,27 +120,30 @@ void splitWorkspace(const std::string& workspace)
 
 void splitCycleWorkspaces(const std::string& value)
 {
-    int delta = getDelta(value);
-	if (delta == 0) {
-		return;
-	}
-    auto* monitor = getCurrentMonitor();
-	auto workspaces = g_vMonitorWorkspaceMap[monitor->ID];
-	int index = -1;
-	for (int i = 0; i < g_workspaceCount; i++) {
-		if (workspaces[i] == monitor->activeWorkspace->m_szName) {
-			index = i;
-			break;
-		}
-	}
-	if (index == -1)
-		return;
+    int const delta = getDelta(value);
+    if (delta == 0) {
+        Debug::log(WARN, "[split-monitor-workspaces] Invalid cycle value: {}", value.c_str());
+        return;
+    }
+    auto* const monitor = getCurrentMonitor();
+    auto const workspaces = g_vMonitorWorkspaceMap[monitor->ID];
+    int index = -1;
+    for (int i = 0; i < g_workspaceCount; i++) {
+        if (workspaces[i] == monitor->activeWorkspace->m_szName) {
+            index = i;
+            break;
+        }
+    }
+    if (index == -1) {
+        Debug::log(WARN, "[split-monitor-workspaces] Could not find active workspace in monitor workspaces. Aborting cycle.");
+        return;
+    }
 
-	index += delta;
+    index += delta;
     if (index < 0)
         index = g_workspaceCount - 1;
     else if (index >= g_workspaceCount)
-		index = 0;
+        index = 0;
 
     HyprlandAPI::invokeHyprctlCommand("dispatch", "workspace " + workspaces[index]);
 }


### PR DESCRIPTION
Added a dispatcher to allow cycling through workspaces per monitor.

Usage:
```
bind = $mod, mouse_down, split-cycleworkspaces, prev
bind = $mod, mouse_up, split-cycleworkspaces, next
```
I've been using this for a while on my two monitor setup and it works great. I did some testing with 6, 8 and 10 workspaces, but I think is should work as is for any config.