### PR TITLE
Focus primary monitor after mapping, if cursor:default_monitor is set in Hyprland config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,5 +61,6 @@ clangd:
 	echo "$(COMPILE_FLAGS) $(COMPILE_DEFINES)" | \
 	sed 's/--no-gnu-unique//g' | \
 	sed 's/ -/\n-/g' | \
+	sed 's/-fno-gnu-unique//g' | \
 	sed 's/std=c++23/std=c++2b/g' \
 	> compile_flags.txt


### PR DESCRIPTION
Closes #208

I'll add support for monitor descriptions later, but I think I'll add that to Hyprland itself first (Hyprland seems to only work with output names which is kind of annoying. (created an issue: https://github.com/hyprwm/Hyprland/discussions/12275)
