### PR TITLE
Fix for Hyprland 0.52.2

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,7 +3,6 @@
 #include <hyprland/src/Compositor.hpp>
 #include <hyprland/src/config/ConfigManager.hpp>
 #include <hyprland/src/desktop/Workspace.hpp>
-#include <hyprland/src/desktop/state/FocusState.hpp>
 #include <hyprland/src/helpers/Color.hpp>
 #include <hyprland/src/managers/KeybindManager.hpp>
 #include <hyprutils/memory/SharedPtr.hpp>
@@ -204,7 +203,7 @@ static const std::string& getWorkspaceFromMonitor(const PHLMONITOR& monitor, con
 static PHLMONITOR getCurrentMonitor()
 {
     // get last focused monitor, because some people switch monitors with a keybind while the cursor is on a different monitor
-    if (PHLMONITOR monitor = Desktop::focusState()->monitor()) {
+    if (PHLMONITOR monitor = g_pCompositor->m_lastMonitor.lock()) {
         return monitor;
     }
     Debug::log(WARN, "[split-monitor-workspaces] Last monitor does not exist, falling back to cursor's monitor");


### PR DESCRIPTION
Hi and thanks for this plugin!
It looks like Hyprland 0.52.2 had some breaking changes and thie plugin wouldn't compile anymore.
The state directory seems to be [gone](https://github.com/hyprwm/Hyprland/tree/v0.52.2-b/src/desktop).
I'm not very familiar with Hyprland plugins but hopefully, this fixes it.