### PR TITLE
Fix an oversight while add new feature gnome-like monitor linking

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -319,7 +319,7 @@ static SDispatchResult splitMoveToWorkspace(const std::string& workspace)
 {
     if (!g_linkMonitors) {
         // not linked => just move to workspace on current monitor
-        auto const result = HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspace " + workspace);
+        auto const result = HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspace " + getWorkspaceFromMonitor(getCurrentMonitor(), workspace));
         return {.success = result == "ok", .error = result};
     }
     // workspaces are linked => silently move to workspace, then change workspace on all monitors


### PR DESCRIPTION
There was an little oversight on the gnome-like monitor linking commit that moved the window on the first monitor.
I have just added the call of getWorkspaceFromMonitor that was missing. 