### PR TITLE
feat: use hy3 dispatchers when hy3 plugin is loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ It also provides the following config values
 | `plugin:split-monitor-workspaces:monitor_priority`              | keyword   | -         | Set per monitor priorities. The first monitor in the list will have the highest priority, the second monitor one lower and so on. |
 | `plugin:split-monitor-workspaces:max_workspaces`                | keyword   | -         | Set per monitor maximum number of workspaces that should be created. |
 | `plugin:split-monitor-workspaces:link_monitors`                 | boolean   | 0         | Enable gnome-like workspace switching. When enabled, switching workspaces on one monitor will switch all monitors to the corresponding workspace. |
+| `plugin:split-monitor-workspaces:enable_hy3`                    | boolean   | 1         | Enable hy3 support. When enabled and the [hy3](https://github.com/outfoxxed/hy3) plugin is loaded, move operations will use hy3 dispatchers to move entire node groups (multiple windows) across workspaces. |
 
 This plugin supports [waybar's](https://github.com/Alexays/Waybar) `hyprland/workspaces` module. You can configure it like this:
 
@@ -171,6 +172,9 @@ plugin {
 
         # set this to 1 for gnome-like workspace switching
         link_monitors = 0
+
+        # set this to 0 to disable hy3 support
+        # enable_hy3 = 1
 
         # if you want a different monitor order
         monitor_priority = DP-1, DVI-D-1

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -38,9 +38,15 @@ static bool g_enablePersistentWorkspaces = true;
 static bool g_enableWrapping = true;
 static std::string g_defaultMonitor = "";
 static bool g_linkMonitors = false;
-static bool g_enableHy3 = true;
-static bool g_hy3Available = false;
-static bool g_hy3Detected = false; // whether detection has been performed
+
+// Hy3 explicit support
+enum class Hy3Status {
+    DISABLED,          // disabled in config
+    DETECTION_PENDING, // not yet performed
+    NOT_DETECTED,      // detection failed
+    DETECTED,          // detection succeeded
+};
+static Hy3Status g_hy3Status = Hy3Status::DETECTION_PENDING;
 
 // the first time we load the plugin, we want to switch to the first workspace on the primary monitor regardless of keepFocused
 static bool g_firstLoad = true;
@@ -81,22 +87,22 @@ static void raiseNotification(const std::string& message, float timeout = 5000.0
 
 static bool isHy3Available()
 {
-    if (!g_enableHy3)
+    if (g_hy3Status == Hy3Status::DISABLED || g_hy3Status == Hy3Status::NOT_DETECTED)
         return false;
 
-    if (g_hy3Detected)
-        return g_hy3Available;
+    if (g_hy3Status == Hy3Status::DETECTED)
+        return true;
 
     // lazy detection: check if the hy3 plugin is loaded by querying the plugin list
     auto const pluginList = HyprlandAPI::invokeHyprctlCommand("plugin", "list");
-    g_hy3Available = pluginList.find("hy3") != std::string::npos;
-    g_hy3Detected = true;
-
-    if (g_hy3Available) {
+    if (pluginList.find("hy3") != std::string::npos) {
+        g_hy3Status = Hy3Status::DETECTED;
         Log::logger->log(Log::INFO, "[split-monitor-workspaces] hy3 plugin detected, using hy3 dispatchers for move operations");
+        return true;
     }
 
-    return g_hy3Available;
+    g_hy3Status = Hy3Status::NOT_DETECTED;
+    return false;
 }
 
 static std::string dispatchMoveToWorkspace(const std::string& workspaceName)
@@ -641,8 +647,12 @@ static void loadConfigValues()
     g_enableWrapping = getConfigValue<Hyprlang::INT>(k_enableWrapping) != 0;
     g_defaultMonitor = getConfigValue<Hyprlang::STRING>(k_defaultMonitor);
     g_linkMonitors = getConfigValue<Hyprlang::INT>(k_linkMonitors) != 0;
-    g_enableHy3 = getConfigValue<Hyprlang::INT>(k_enableHy3) != 0;
-    g_hy3Detected = false; // reset detection so it re-checks on next use
+    if (getConfigValue<Hyprlang::INT>(k_enableHy3) != 0) {
+        g_hy3Status = Hy3Status::DETECTION_PENDING; // reset so it re-checks on next use
+    }
+    else {
+        g_hy3Status = Hy3Status::DISABLED;
+    }
     Log::logger->log(Log::INFO,
                      "[split-monitor-workspaces] Config values loaded: workspaceCount={}, keepFocused={}, enableNotifications={}, enablePersistentWorkspaces={}, enableWrapping={}, "
                      "defaultMonitor='{}', linkMonitors={}",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -9,6 +9,7 @@
 #include <hyprland/src/event/EventBus.hpp>
 #include <hyprland/src/helpers/Color.hpp>
 #include <hyprland/src/helpers/Monitor.hpp>
+#include <hyprland/src/managers/KeybindManager.hpp>
 #include <hyprutils/memory/SharedPtr.hpp>
 #include <hyprutils/string/VarList2.hpp>
 
@@ -93,9 +94,8 @@ static bool isHy3Available()
     if (g_hy3Status == Hy3Status::DETECTED)
         return true;
 
-    // lazy detection: check if the hy3 plugin is loaded by querying the plugin list
-    auto const pluginList = HyprlandAPI::invokeHyprctlCommand("plugin", "list");
-    if (pluginList.find("hy3") != std::string::npos) {
+    // detection: check if the hy3 plugin registered its dispatcher
+    if (g_pKeybindManager->m_dispatchers.contains("hy3:movetoworkspace")) {
         g_hy3Status = Hy3Status::DETECTED;
         Log::logger->log(Log::INFO, "[split-monitor-workspaces] hy3 plugin detected, using hy3 dispatchers for move operations");
         return true;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -105,20 +105,18 @@ static bool isHy3Available()
     return false;
 }
 
-static std::string dispatchMoveToWorkspace(const std::string& workspaceName)
+static std::string dispatchMoveToWorkspace(const std::string& workspaceName, bool silent)
 {
     if (isHy3Available()) {
+        if (silent) {
+            return HyprlandAPI::invokeHyprctlCommand("dispatch", "hy3:movetoworkspace " + workspaceName);
+        }
         return HyprlandAPI::invokeHyprctlCommand("dispatch", "hy3:movetoworkspace " + workspaceName + ",follow");
     }
-    return HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspace " + workspaceName);
-}
-
-static std::string dispatchMoveToWorkspaceSilent(const std::string& workspaceName)
-{
-    if (isHy3Available()) {
-        return HyprlandAPI::invokeHyprctlCommand("dispatch", "hy3:movetoworkspace " + workspaceName);
+    if (silent) {
+        return HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspacesilent " + workspaceName);
     }
-    return HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspacesilent " + workspaceName);
+    return HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspace " + workspaceName);
 }
 
 // avoid default initialization with []
@@ -379,18 +377,18 @@ static SDispatchResult splitMoveToWorkspace(const std::string& workspace)
 {
     if (!g_linkMonitors) {
         // not linked => just move to workspace on current monitor
-        auto const result = dispatchMoveToWorkspace(getWorkspaceFromMonitor(getCurrentMonitor(), workspace));
+        auto const result = dispatchMoveToWorkspace(getWorkspaceFromMonitor(getCurrentMonitor(), workspace), false);
         return {.success = result == "ok", .error = result};
     }
     // workspaces are linked => silently move to workspace, then change workspace on all monitors
-    auto const result = dispatchMoveToWorkspaceSilent(getWorkspaceFromMonitor(getCurrentMonitor(), workspace));
+    auto const result = dispatchMoveToWorkspace(getWorkspaceFromMonitor(getCurrentMonitor(), workspace), true);
     splitWorkspace(workspace);
     return {.success = result == "ok", .error = result};
 }
 
 static SDispatchResult splitMoveToWorkspaceSilent(const std::string& workspace)
 {
-    auto const result = dispatchMoveToWorkspaceSilent(getWorkspaceFromMonitor(getCurrentMonitor(), workspace));
+    auto const result = dispatchMoveToWorkspace(getWorkspaceFromMonitor(getCurrentMonitor(), workspace), true);
     return {.success = result == "ok", .error = result};
 }
 
@@ -430,10 +428,10 @@ static SDispatchResult changeMonitor(bool quiet, const std::string& value)
 
     std::string result;
     if (quiet) {
-        result = dispatchMoveToWorkspaceSilent(std::to_string(nextWorkspaceID));
+        result = dispatchMoveToWorkspace(std::to_string(nextWorkspaceID), true);
     }
     else {
-        result = dispatchMoveToWorkspace(std::to_string(nextWorkspaceID));
+        result = dispatchMoveToWorkspace(std::to_string(nextWorkspaceID), false);
     }
     return {.success = result == "ok", .error = result};
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -27,6 +27,7 @@ auto constexpr k_defaultMonitor = "cursor:default_monitor";
 auto constexpr k_monitorPriority = "plugin:split-monitor-workspaces:monitor_priority";
 auto constexpr k_monitorMaxWorkspaces = "plugin:split-monitor-workspaces:max_workspaces";
 auto constexpr k_linkMonitors = "plugin:split-monitor-workspaces:link_monitors";
+auto constexpr k_enableHy3 = "plugin:split-monitor-workspaces:enable_hy3";
 
 static const CHyprColor s_pluginColor = {0x61 / 255.0F, 0xAF / 255.0F, 0xEF / 255.0F, 1.0F};
 
@@ -37,6 +38,9 @@ static bool g_enablePersistentWorkspaces = true;
 static bool g_enableWrapping = true;
 static std::string g_defaultMonitor = "";
 static bool g_linkMonitors = false;
+static bool g_enableHy3 = true;
+static bool g_hy3Available = false;
+static bool g_hy3Detected = false; // whether detection has been performed
 
 // the first time we load the plugin, we want to switch to the first workspace on the primary monitor regardless of keepFocused
 static bool g_firstLoad = true;
@@ -73,6 +77,42 @@ static void raiseNotification(const std::string& message, float timeout = 5000.0
     if (g_enableNotifications) {
         HyprlandAPI::addNotification(PHANDLE, message, s_pluginColor, timeout);
     }
+}
+
+static bool isHy3Available()
+{
+    if (!g_enableHy3)
+        return false;
+
+    if (g_hy3Detected)
+        return g_hy3Available;
+
+    // lazy detection: check if the hy3 plugin is loaded by querying the plugin list
+    auto const pluginList = HyprlandAPI::invokeHyprctlCommand("plugin", "list");
+    g_hy3Available = pluginList.find("hy3") != std::string::npos;
+    g_hy3Detected = true;
+
+    if (g_hy3Available) {
+        Log::logger->log(Log::INFO, "[split-monitor-workspaces] hy3 plugin detected, using hy3 dispatchers for move operations");
+    }
+
+    return g_hy3Available;
+}
+
+static std::string dispatchMoveToWorkspace(const std::string& workspaceName)
+{
+    if (isHy3Available()) {
+        return HyprlandAPI::invokeHyprctlCommand("dispatch", "hy3:movetoworkspace " + workspaceName + ",follow");
+    }
+    return HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspace " + workspaceName);
+}
+
+static std::string dispatchMoveToWorkspaceSilent(const std::string& workspaceName)
+{
+    if (isHy3Available()) {
+        return HyprlandAPI::invokeHyprctlCommand("dispatch", "hy3:movetoworkspace " + workspaceName);
+    }
+    return HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspacesilent " + workspaceName);
 }
 
 // avoid default initialization with []
@@ -333,18 +373,18 @@ static SDispatchResult splitMoveToWorkspace(const std::string& workspace)
 {
     if (!g_linkMonitors) {
         // not linked => just move to workspace on current monitor
-        auto const result = HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspace " + getWorkspaceFromMonitor(getCurrentMonitor(), workspace));
+        auto const result = dispatchMoveToWorkspace(getWorkspaceFromMonitor(getCurrentMonitor(), workspace));
         return {.success = result == "ok", .error = result};
     }
     // workspaces are linked => silently move to workspace, then change workspace on all monitors
-    auto const result = HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspacesilent " + getWorkspaceFromMonitor(getCurrentMonitor(), workspace));
+    auto const result = dispatchMoveToWorkspaceSilent(getWorkspaceFromMonitor(getCurrentMonitor(), workspace));
     splitWorkspace(workspace);
     return {.success = result == "ok", .error = result};
 }
 
 static SDispatchResult splitMoveToWorkspaceSilent(const std::string& workspace)
 {
-    auto const result = HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspacesilent " + getWorkspaceFromMonitor(getCurrentMonitor(), workspace));
+    auto const result = dispatchMoveToWorkspaceSilent(getWorkspaceFromMonitor(getCurrentMonitor(), workspace));
     return {.success = result == "ok", .error = result};
 }
 
@@ -384,10 +424,10 @@ static SDispatchResult changeMonitor(bool quiet, const std::string& value)
 
     std::string result;
     if (quiet) {
-        result = HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspacesilent " + std::to_string(nextWorkspaceID));
+        result = dispatchMoveToWorkspaceSilent(std::to_string(nextWorkspaceID));
     }
     else {
-        result = HyprlandAPI::invokeHyprctlCommand("dispatch", "movetoworkspace " + std::to_string(nextWorkspaceID));
+        result = dispatchMoveToWorkspace(std::to_string(nextWorkspaceID));
     }
     return {.success = result == "ok", .error = result};
 }
@@ -601,6 +641,8 @@ static void loadConfigValues()
     g_enableWrapping = getConfigValue<Hyprlang::INT>(k_enableWrapping) != 0;
     g_defaultMonitor = getConfigValue<Hyprlang::STRING>(k_defaultMonitor);
     g_linkMonitors = getConfigValue<Hyprlang::INT>(k_linkMonitors) != 0;
+    g_enableHy3 = getConfigValue<Hyprlang::INT>(k_enableHy3) != 0;
+    g_hy3Detected = false; // reset detection so it re-checks on next use
     Log::logger->log(Log::INFO,
                      "[split-monitor-workspaces] Config values loaded: workspaceCount={}, keepFocused={}, enableNotifications={}, enablePersistentWorkspaces={}, enableWrapping={}, "
                      "defaultMonitor='{}', linkMonitors={}",
@@ -717,6 +759,7 @@ APICALL EXPORT PLUGIN_DESCRIPTION_INFO PLUGIN_INIT(HANDLE handle)
     HyprlandAPI::addConfigKeyword(PHANDLE, k_monitorPriority, monitorPriorityConfigHandler, (Hyprlang::SHandlerOptions){.allowFlags = false});
     HyprlandAPI::addConfigKeyword(PHANDLE, k_monitorMaxWorkspaces, monitorMaxWorkspacesConfigHandler, (Hyprlang::SHandlerOptions){.allowFlags = false});
     HyprlandAPI::addConfigValue(PHANDLE, k_linkMonitors, Hyprlang::INT{0});
+    HyprlandAPI::addConfigValue(PHANDLE, k_enableHy3, Hyprlang::INT{1});
 
     HyprlandAPI::addDispatcherV2(PHANDLE, "split-workspace", splitWorkspace);
     HyprlandAPI::addDispatcherV2(PHANDLE, "split-cycleworkspaces", splitCycleWorkspaces);


### PR DESCRIPTION
When the hy3 layout plugin is detected, use hy3:movetoworkspace instead of the native movetoworkspace/movetoworkspacesilent dispatchers. This allows moving hy3 node groups (multiple windows) across workspaces.

Detection is lazy (performed on first move operation) and re-evaluated on config reload. A new config option enable_hy3 (default: true) allows disabling this behavior.

This is a work I decided to do later after having asked for some kind of resolution [on hy3 repo](https://github.com/outfoxxed/hy3/issues/220). I realized that the most sensible way to fix that was this new PR that I'm making here today.

Looking forward for your comments.