### PR TITLE
docs: update nix example

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ With flakes enabled, a sample installation will look like this:
                 wayland.windowManager.hyprland = {
                   # ...
                   plugins = [
-                    split-monitor-workspaces.packages.${pkgs.system}.split-monitor-workspaces
+                    split-monitor-workspaces.packages.${pkgs.stdenv.hostPlatform.system}.split-monitor-workspaces
                   ];
                   # ...
                 };


### PR DESCRIPTION
When using the example you will get this warning
`evaluation warning: 'system' has been renamed to/replaced by 'stdenv.hostPlatform.system'`
and this just fixes that