### PR TITLE
Fix default monitor not being loaded properly

### DIFF
--- a/src/helpers.hpp
+++ b/src/helpers.hpp
@@ -13,7 +13,7 @@ struct lua_State;
 const char* translateConfigKey(const char* rawKey);
 
 // Get a config value of the specified type.
-template <typename T> auto getConfigValue(const char* paramName);
+template <typename T> std::optional<T> getConfigValue(const char* paramName);
 
 // Raise a Hyprland notification. Nullop if notifications are disabled in the plugin config.
 void raiseNotification(const std::string& message, float timeout = 5000.0F);

--- a/src/helpers.txx
+++ b/src/helpers.txx
@@ -6,17 +6,17 @@
 #include <hyprland/src/macros.hpp>
 #include <hyprlang.hpp>
 
-template <typename T> auto getConfigValue(const char* paramName)
+template <typename T> std::optional<T> getConfigValue(const char* paramName)
 {
     Log::logger->log(Log::INFO, "[split-monitor-workspaces] Getting config value {}", paramName);
 
     if (Config::mgr()->type() == Config::CONFIG_LUA) {
         const auto* const value = Config::mgr()->getConfigValue(paramName).dataptr;
         if (value == nullptr) {
-            Log::logger->log(Log::ERR, "[split-monitor-workspaces] Config value {} not found", paramName);
-            throw std::runtime_error("Config value not found: " + std::string(paramName));
+            Log::logger->log(Log::WARN, "[split-monitor-workspaces] Config value {} not found", paramName);
+            return std::nullopt;
         }
-        return reinterpret_cast<T>(*value);
+        return *reinterpret_cast<const T*>(*value);
     }
 
     // TODO: remove call to deprecated getConfigValue function when fully transitioning to lua config system (sometime after v0.55 probably)
@@ -26,12 +26,14 @@ template <typename T> auto getConfigValue(const char* paramName)
 #pragma GCC diagnostic pop
     if (dataPtr == nullptr) {
         Log::logger->log(Log::WARN, "[split-monitor-workspaces] Config value {} not found", paramName);
+        return std::nullopt;
     }
 
-    if constexpr (std::is_same_v<T, Hyprlang::STRING>) {
+    if constexpr (std::is_same_v<T, Config::STRING>) {
         return *(const char**)dataPtr;
     }
     else {
         return *(T*)*dataPtr;
     }
+    return std::nullopt;
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -396,23 +396,45 @@ void loadConfigValues()
     Log::logger->log(Log::INFO, "[split-monitor-workspaces] Loading config values");
 
     try {
-        g_defaultMonitor = getConfigValue<Hyprlang::STRING>(translateConfigKey(k_defaultMonitor));
-        Log::logger->log(Log::INFO, "[split-monitor-workspaces] Default monitor from config: '{}'", g_defaultMonitor);
+        auto defaultMonitor = getConfigValue<Config::STRING>(translateConfigKey(k_defaultMonitor));
+        if (defaultMonitor.has_value()) {
+            g_defaultMonitor = defaultMonitor.value();
+            Log::logger->log(Log::INFO, "[split-monitor-workspaces] Default monitor from config: '{}'", g_defaultMonitor);
+        }
+        else {
+            Log::logger->log(Log::INFO, "[split-monitor-workspaces] No default monitor specified in config");
+        }
+    }
+    catch (const std::exception& e) {
+        Log::logger->log(Log::WARN, "[split-monitor-workspaces] Failed to get default monitor from config: {}", e.what());
+    }
 
+    try {
         if (g_config.enableHy3->value()) {
             g_hy3Status = Hy3Status::DETECTION_PENDING; // reset so it re-checks on next use
         }
         else {
             g_hy3Status = Hy3Status::DISABLED;
         }
-
-        if (Config::mgr()->type() == Config::CONFIG_LUA) {
-            loadMonitorPriority(getConfigValue<Hyprlang::STRING>(translateConfigKey(k_monitorPriority)));
-            loadMonitorMaxWorkspaces(getConfigValue<Hyprlang::STRING>(translateConfigKey(k_monitorMaxWorkspaces)));
-        }
     }
     catch (const std::exception& e) {
-        Log::logger->log(Log::ERR, "[split-monitor-workspaces] Exception while loading config values: {}", e.what());
+        Log::logger->log(Log::ERR, "[split-monitor-workspaces] Exception while loading Hy3 status from config: {}", e.what());
+    }
+
+    if (Config::mgr()->type() == Config::CONFIG_LUA) {
+        try {
+            auto monitorPriority = getConfigValue<Config::STRING>(translateConfigKey(k_monitorPriority));
+            if (monitorPriority.has_value()) {
+                loadMonitorPriority(monitorPriority.value());
+            }
+            auto monitorMaxWorkspaces = getConfigValue<Config::STRING>(translateConfigKey(k_monitorMaxWorkspaces));
+            if (monitorMaxWorkspaces.has_value()) {
+                loadMonitorMaxWorkspaces(monitorMaxWorkspaces.value());
+            }
+        }
+        catch (const std::exception& e) {
+            Log::logger->log(Log::ERR, "[split-monitor-workspaces] Exception while loading monitor configuration: {}", e.what());
+        }
     }
 }
 


### PR DESCRIPTION
Fixes this issue:

```
[split-monitor-workspaces] Default monitor from config: ' Q@ï¿½U'
```