### PR TITLE
Toggle Monitor on Navigation to Active Workspace

### DIFF
--- a/lua/dispatchers.lua
+++ b/lua/dispatchers.lua
@@ -53,7 +53,8 @@ function dispatchers.do_workspace(workspace_str)
 		local resolved = helpers.get_workspace_from_monitor(current_monitor, workspace_str)
 
 		-- If we're already on this workspace, switch to the next monitor
-		if current_monitor.active_workspace
+		if globals.cfg.toggle_monitor
+				and current_monitor.active_workspace
 				and current_monitor.active_workspace.name == resolved then
 			local monitors = hl.get_monitors()
 

--- a/lua/dispatchers.lua
+++ b/lua/dispatchers.lua
@@ -51,6 +51,29 @@ function dispatchers.do_workspace(workspace_str)
 	else
 		---@type string
 		local resolved = helpers.get_workspace_from_monitor(current_monitor, workspace_str)
+
+		-- If we're already on this workspace, switch to the next monitor
+		if current_monitor.active_workspace
+				and current_monitor.active_workspace.name == resolved then
+			local monitors = hl.get_monitors()
+
+			for i, monitor in ipairs(monitors) do
+				if monitor.id == current_monitor.id then
+					local next_monitor = monitors[(i % #monitors) + 1]
+
+					if next_monitor.active_workspace then
+						hl.dispatch(
+							hl.dsp.focus({
+								workspace = next_monitor.active_workspace.name
+							})
+						)
+					end
+
+					return
+				end
+			end
+		end
+
 		hl.dispatch(hl.dsp.focus({ workspace = resolved }))
 	end
 end

--- a/lua/globals.lua
+++ b/lua/globals.lua
@@ -13,6 +13,7 @@
 ---@field enable_persistent_workspaces boolean?
 ---@field enable_wrapping boolean?
 ---@field link_monitors boolean?
+---@field toggle_monitor boolean?
 ---@field monitor_priority string[]?
 ---@field max_workspaces table<string, integer>?
 
@@ -46,6 +47,9 @@ globals.cfg = {
 
 	--- If true, switching workspaces changes all monitors simultaneously (Gnome-style).
 	link_monitors = false,
+
+	--- If true, switching to active workspace will focus the next monitor
+	toggle_monitor = false,
 
 	--- List of monitor names in priority order (determines workspace range allocation).
 	--- Monitors not listed get priorities assigned in the order Hyprland reports them.


### PR DESCRIPTION
## Motivation
I've found it annoying to 'tab-out' from games on a dual monitor setup with Hyprland.

## Overview
Therefore, I thought of this feature when navigating to the active (relative) workspace on a monitor will focus the next monitor. 

In other words, with 2 monitors and 5 workspaces per monitor:
  - **state:** monitor 1, workspace 2 (actual 2):
    - **action:** navigate to split workspace 2 -> **result:** focus monitor 2
  - **state:** monitor 2, workspace 2 (actual 7)
    - **action:** navigate to split workspace 2 -> **result:** focus monitor 1

## Config
This option might be annoying for users with 3+ monitors and I think should be disabled by default.
The config key is `toggle_monitor`. 

## Demo
I've been using this for a couple months and still find it hard to explain so I'll attach a demo clip

https://github.com/user-attachments/assets/15e3cff9-9227-4cba-a7e4-c3e6c0e058fd