### PR TITLE
Add monitor description matching support with "desc:..."

### DIFF
--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -148,6 +148,48 @@ function helpers.resolve_monitor_identifier(identifier)
 	return nil
 end
 
+--- Registers priorities and workspace-count overrides for all currenlty available monitors
+function helpers.load_config_for_all_monitors()
+    --- Load monitor_priority list into the priorities map.
+    for i, name in ipairs(globals.cfg.monitor_priority) do
+        ---@type string|nil
+        local resolved = helpers.resolve_monitor_identifier(name)
+        if resolved then
+            globals.monitor_priorities[resolved] = { value = i - 1, from_config = true }
+        else
+            print("[split-monitor-workspaces] no monitor matched '" .. name .. "'")
+        end
+    end
+
+    --- Load per-monitor max_workspaces overrides.
+    for name, count in pairs(globals.cfg.max_workspaces) do
+        ---@type string|nil
+        local resolved = helpers.resolve_monitor_identifier(name)
+        if resolved then
+            globals.monitor_max_ws_override[resolved] = { value = count, from_config = true }
+        else
+            print("[split-monitor-workspaces] no monitor matched '" .. name .. "'")
+        end
+    end
+end
+
+--- Registers priorities and workspace-count overrides only for the passed monitor
+---@param monitor HL.Monitor
+function helpers.load_config_for_monitor(monitor)
+    for i, name in ipairs(globals.cfg.monitor_priority) do
+        if helpers.resolve_monitor_identifier(name) == monitor.name then
+            globals.monitor_priorities[monitor.name] = { value = i - 1, from_config = true }
+            helpers.notify("[monitor_priority SINGLE] " .. name)
+        end
+    end
+    for name, count in pairs(globals.cfg.max_workspaces) do
+        if helpers.resolve_monitor_identifier(name) == monitor.name then
+            globals.monitor_max_ws_override[monitor.name] = { value = count, from_config = true }
+            helpers.notify("[max_workspaces overrides SINGLE] " .. name)
+        end
+    end
+end
+
 --- ============================================================
 --- Workspace name resolution
 --

--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -129,8 +129,8 @@ function helpers.resolve_monitor_identifier(identifier)
 		return identifier
 	end
 
-    --- trim trailing spaces just in case
-	desc_prefix = desc_prefix:gsub("%s+$", "")
+    -- trim leading and trailing spaces just in case
+    desc_prefix = desc_prefix:gsub("^%s+", ""):gsub("%s+$", "")
 	if desc_prefix == "" then
 		return nil
 	end

--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -150,26 +150,8 @@ end
 
 --- Registers priorities and workspace-count overrides for all currently available monitors
 function helpers.load_config_for_all_monitors()
-    --- Load monitor_priority list into the priorities map.
-    for i, name in ipairs(globals.cfg.monitor_priority) do
-        ---@type string|nil
-        local resolved = helpers.resolve_monitor_identifier(name)
-        if resolved then
-            globals.monitor_priorities[resolved] = { value = i - 1, from_config = true }
-        else
-            print("[split-monitor-workspaces] no monitor matched '" .. name .. "'")
-        end
-    end
-
-    --- Load per-monitor max_workspaces overrides.
-    for name, count in pairs(globals.cfg.max_workspaces) do
-        ---@type string|nil
-        local resolved = helpers.resolve_monitor_identifier(name)
-        if resolved then
-            globals.monitor_max_ws_override[resolved] = { value = count, from_config = true }
-        else
-            print("[split-monitor-workspaces] no monitor matched '" .. name .. "'")
-        end
+    for _, monitor in ipairs(hl.get_monitors()) do
+        helpers.load_config_for_monitor(monitor)
     end
 end
 
@@ -179,13 +161,11 @@ function helpers.load_config_for_monitor(monitor)
     for i, name in ipairs(globals.cfg.monitor_priority) do
         if helpers.resolve_monitor_identifier(name) == monitor.name then
             globals.monitor_priorities[monitor.name] = { value = i - 1, from_config = true }
-            helpers.notify("[monitor_priority SINGLE] " .. name)
         end
     end
     for name, count in pairs(globals.cfg.max_workspaces) do
         if helpers.resolve_monitor_identifier(name) == monitor.name then
             globals.monitor_max_ws_override[monitor.name] = { value = count, from_config = true }
-            helpers.notify("[max_workspaces overrides SINGLE] " .. name)
         end
     end
 end

--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -110,6 +110,45 @@ function helpers.calc_base_index(monitor_name)
 end
 
 --- ============================================================
+--- Monitor identifier resolution
+---
+--- Accepts either a plain port name ("DP-2") or a description with
+--- the "desc:" prefix ("desc:ViewSonic Corporation VX2758A-QHD").
+--- Description matching is a prefix match, so make+model is enough
+--- for the match to succeed and the trailing serial can be omitted.
+--- ============================================================
+---@param identifier string
+---@return string|nil
+function helpers.resolve_monitor_identifier(identifier)
+    --- extract the part after "desc:" or nil if there's no prefix
+	---@type string|nil
+	local desc_prefix = identifier:match("^desc:(.*)$")
+
+    --- plain port name, return as-is
+	if not desc_prefix then
+		return identifier
+	end
+
+    --- trim trailing spaces just in case
+	desc_prefix = desc_prefix:gsub("%s+$", "")
+	if desc_prefix == "" then
+		return nil
+	end
+
+    --- match the prefix against each monitor's description
+	for _, monitor in ipairs(hl.get_monitors()) do
+		---@type string
+		local desc = monitor.description or ""
+		if desc:sub(1, #desc_prefix) == desc_prefix then
+			return monitor.name
+		end
+	end
+
+    --- no monitor matches the description
+	return nil
+end
+
+--- ============================================================
 --- Workspace name resolution
 --
 --- Given a monitor and a user-facing workspace string, returns the

--- a/lua/helpers.lua
+++ b/lua/helpers.lua
@@ -148,7 +148,7 @@ function helpers.resolve_monitor_identifier(identifier)
 	return nil
 end
 
---- Registers priorities and workspace-count overrides for all currenlty available monitors
+--- Registers priorities and workspace-count overrides for all currently available monitors
 function helpers.load_config_for_all_monitors()
     --- Load monitor_priority list into the priorities map.
     for i, name in ipairs(globals.cfg.monitor_priority) do

--- a/lua/split-monitor-workspaces.lua
+++ b/lua/split-monitor-workspaces.lua
@@ -66,15 +66,31 @@ function api.setup(user_config)
 		end
 	end
 
-	--- Load monitor_priority list into the priorities map.
-	for i, name in ipairs(globals.cfg.monitor_priority) do
-		globals.monitor_priorities[name] = { value = i - 1, from_config = true }
+	local function load_config_monitors()
+        --- Load monitor_priority list into the priorities map.
+		for i, name in ipairs(globals.cfg.monitor_priority) do
+			---@type string|nil
+			local resolved = helpers.resolve_monitor_identifier(name)
+			if resolved then
+				globals.monitor_priorities[resolved] = { value = i - 1, from_config = true }
+			else
+				print("[split-monitor-workspaces] no monitor matched '" .. name .. "'")
+			end
+		end
+
+        --- Load per-monitor max_workspaces overrides.
+		for name, count in pairs(globals.cfg.max_workspaces) do
+			---@type string|nil
+			local resolved = helpers.resolve_monitor_identifier(name)
+			if resolved then
+				globals.monitor_max_ws_override[resolved] = { value = count, from_config = true }
+			else
+				print("[split-monitor-workspaces] no monitor matched '" .. name .. "'")
+			end
+		end
 	end
 
-	--- Load per-monitor max_workspaces overrides.
-	for name, count in pairs(globals.cfg.max_workspaces) do
-		globals.monitor_max_ws_override[name] = { value = count, from_config = true }
-	end
+    load_config_monitors()
 
 	--- Register event handlers.
 	hl.on("monitor.added", function(monitor)
@@ -91,6 +107,7 @@ function api.setup(user_config)
 		for name, p in pairs(globals.monitor_max_ws_override) do
 			if not p.from_config then globals.monitor_max_ws_override[name] = nil end
 		end
+        load_config_monitors()
 		monitors.remap_all_monitors()
 		helpers.notify("Initialized successfully!")
 	end)

--- a/lua/split-monitor-workspaces.lua
+++ b/lua/split-monitor-workspaces.lua
@@ -66,34 +66,9 @@ function api.setup(user_config)
 		end
 	end
 
-	local function load_config_monitors()
-        --- Load monitor_priority list into the priorities map.
-		for i, name in ipairs(globals.cfg.monitor_priority) do
-			---@type string|nil
-			local resolved = helpers.resolve_monitor_identifier(name)
-			if resolved then
-				globals.monitor_priorities[resolved] = { value = i - 1, from_config = true }
-			else
-				print("[split-monitor-workspaces] no monitor matched '" .. name .. "'")
-			end
-		end
-
-        --- Load per-monitor max_workspaces overrides.
-		for name, count in pairs(globals.cfg.max_workspaces) do
-			---@type string|nil
-			local resolved = helpers.resolve_monitor_identifier(name)
-			if resolved then
-				globals.monitor_max_ws_override[resolved] = { value = count, from_config = true }
-			else
-				print("[split-monitor-workspaces] no monitor matched '" .. name .. "'")
-			end
-		end
-	end
-
-    load_config_monitors()
-
 	--- Register event handlers.
 	hl.on("monitor.added", function(monitor)
+        helpers.load_config_for_monitor(monitor)
 		monitors.map_monitor(monitor)
 	end)
 	hl.on("monitor.removed", function(monitor)
@@ -107,7 +82,7 @@ function api.setup(user_config)
 		for name, p in pairs(globals.monitor_max_ws_override) do
 			if not p.from_config then globals.monitor_max_ws_override[name] = nil end
 		end
-        load_config_monitors()
+        helpers.load_config_for_all_monitors()
 		monitors.remap_all_monitors()
 		helpers.notify("Initialized successfully!")
 	end)


### PR DESCRIPTION
I saw the #246 feature request and thought I'd give it a shot. I'm not that confident in my Lua writing skills so please do double-check haha.

The matching work by finding "desc:" at the beginning of the identifier, cutting it out and then using what's left to match against the first thing it finds in `hl.get_monitors()`. **It's only a prefix match**. Meaning it can be a complete match where you just copy waste the entire description from `hyprctl monitors`, but you can also do a partial match as long as the monitor description **starts** with whatever identifier you configured. After the matching is done, it returns the port name so it shouldn't affect any other logic. Since only during the setup the description is resolved.

Usage:
You can put full monitor description = "desc:Samsung Electric Company S22R35x H4TN....."
Partial description = "desc:Samsung Electric Company"

So far I've tested with two monitors with different names. Works for `monitor_priority` and `max_workspaces` as well. Also tested with `enable_persistent_workspaces = true` and `max_workspaces` as you can see below.

Setup configuration:
```lua
smw.setup({
	workspace_count = 10,
	monitor_priority = { "DP-2", "desc:Samsung Electric" },
	keep_focused = true,
	enable_persistent_workspaces = false,
	link_monitors = false,
	max_workspaces = {
		["DP-2"] = 10,
		["desc:Samsung Electric Company S22R35x"] = 4,
	},
})
```

`hyprctl monitors`:
```bash
Monitor HDMI-A-1 (ID 1):
	1920x1080@74.97300 at -1920x180
	description: Samsung Electric Company S22R35x H4TN.....
	make: Samsung Electric Company
	model: S22R35x
```